### PR TITLE
fix: members image position

### DIFF
--- a/css/members.css
+++ b/css/members.css
@@ -61,6 +61,8 @@ section {
 .basic-details {
     position: relative;
     z-index: 20; /* Has to be more than the z-index of inner-details on hover */
+    display: flex;
+    flex-direction: column;
 }
 
 .basic-details .member-image {


### PR DESCRIPTION
if names are big then that member image is not in the same horizontal

in the gopu's image here
![fix](https://user-images.githubusercontent.com/51911161/159851745-e477e310-93e0-4ec4-98be-145adaf40bbf.png)

fixed:
![fixed](https://user-images.githubusercontent.com/51911161/159851803-b8194ed1-910f-4454-8076-8394c80b5da8.png)

